### PR TITLE
Add files via upload

### DIFF
--- a/disp_hitboxes.lua
+++ b/disp_hitboxes.lua
@@ -204,6 +204,10 @@ re.on_frame(function()
             local actParam = obj.mpActParam
             if actParam and not obj:get_IsR0Die() then
                 draw_boxes(obj, actParam)
+				local objPos = draw.world_to_screen(Vector3f.new(obj.pos.x.v / 6553600.0, obj.pos.y.v / 6553600.0, 0))
+					if objPos and display_position then
+					draw.filled_circle(objPos.x, objPos.y, 10, 0xFFFFFFFF, 10);
+				end
             end
         end
         local sPlayer = gBattle:get_field("Player"):get_data(nil)


### PR DESCRIPTION
Hitbox Display:
1. Now shows the position of projectile entities

Info Display:
1. Added `root_pos` (tracks the position of a player before starting a new action)
2. Added true Action IDs (indicates which Action/State an entity is in)
3. Added Action Frame Counter (indicates which frame of an Action the entity is in)
4. Added Margin Frame (indicates what frame an action can be canceled)
5. Added Total Frame (indicates the total length of an animation if left uncanceled)
6. Added Throw Protection Timer (reflects how long a player cannot be thrown for)
7. Added Intangibility Timer (reflects how long a player is intangible)