### PR TITLE
 Display the current hitstop along with the max hitstop

### DIFF
--- a/info_display.lua
+++ b/info_display.lua
@@ -136,7 +136,7 @@ re.on_frame(function()
 		p1.current_HP = cPlayer[0].vital_new
 		p1.HP_cooldown = cPlayer[0].healing_wait
         p1.dir = bitand(cPlayer[0].BitValue, 128) == 128
-        p1.hitstop = cPlayer[0].hit_stop
+        p1.curr_hitstop = cPlayer[0].hit_stop
 		p1.hitstun = cPlayer[0].damage_time
 		p1.blockstun = cPlayer[0].guard_time
         p1.stance = cPlayer[0].pose_st
@@ -165,7 +165,7 @@ re.on_frame(function()
 		p2.current_HP = cPlayer[1].vital_new
 		p2.HP_cooldown = cPlayer[1].healing_wait
         p2.dir = bitand(cPlayer[1].BitValue, 128) == 128
-        p2.hitstop = cPlayer[1].hit_stop
+        p2.curr_hitstop = cPlayer[1].hit_stop
 		p2.hitstun = cPlayer[1].damage_time
 		p2.blockstun = cPlayer[1].guard_time
         p2.stance = cPlayer[1].pose_st
@@ -185,6 +185,23 @@ re.on_frame(function()
         p2.aclY = cPlayer[1].alpha.y.v / 6553600.0
 		p2.pushback = cPlayer[1].vector_zuri.speed.v / 6553600.0
 
+		if p1.max_hitstop == nil then
+			p1.max_hitstop = 0
+		end
+		if p1.curr_hitstop > p1.max_hitstop then
+			p1.max_hitstop = p1.curr_hitstop
+		elseif p1.curr_hitstop == 0 then
+			p1.max_hitstop = 0
+		end
+
+		if p2.max_hitstop == nil then
+			p2.max_hitstop = 0
+		end
+		if p2.curr_hitstop > p2.max_hitstop then
+			p2.max_hitstop = p2.curr_hitstop
+		elseif p2.curr_hitstop == 0 then
+			p2.max_hitstop = 0
+		end
 
 		if display_player_info then
 			imgui.begin_window("Player Data", true, 0)
@@ -229,7 +246,7 @@ re.on_frame(function()
 					imgui.tree_pop()
 				end
 				if imgui.tree_node("Attack Info") then
-					imgui.text("Hitstop: " .. p1.hitstop)
+					imgui.text("Hitstop: " .. p1.curr_hitstop .. " (" .. p1.max_hitstop .. ")")
 					imgui.text("Hitstun: " .. p1.hitstun)
 					imgui.text("Blockstun: " .. p1.blockstun)
 					imgui.text("Juggle Counter: " .. p2.juggle)
@@ -297,7 +314,7 @@ re.on_frame(function()
 					imgui.tree_pop()
 				end
 				if imgui.tree_node("Attack Info") then
-					imgui.text("Hitstop: " .. p2.hitstop)
+					imgui.text("Hitstop: " .. p2.curr_hitstop .. " (" .. p2.max_hitstop .. ")")
 					imgui.text("Hitstun: " .. p2.hitstun)
 					imgui.text("Blockstun: " .. p2.blockstun)
 					imgui.text("Juggle Counter: " .. p1.juggle)


### PR DESCRIPTION
The current hitstop is changing too fast to see.
So I record the max hitstop, and clear it after the current hitstop ends.
